### PR TITLE
use HTTP keep-alive

### DIFF
--- a/src/journal-gateway-gelf.c
+++ b/src/journal-gateway-gelf.c
@@ -378,7 +378,7 @@ static void *handler_routine () {
     curl = curl_easy_init();
     assert(curl);
 
-    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "journal-gateway-gelf/1.0");
     curl_easy_setopt(curl, CURLOPT_URL, gateway_socket_address);
 


### PR DESCRIPTION
instead of opening a new TCP connection for every log message, keep
the same connection open. this is achieved by switching from
HTTP_VERSION_1_0 to HTTP_VERSION_1_1. in HTTP-1.1, keep-alive is the
default mode of operation, for HTTP-1.0 keep-alive would have to be
enabled explicitely.
